### PR TITLE
🧹 Remove redundant null check in NavigationMenu

### DIFF
--- a/components/NavigationMenu/NavigationMenu.js
+++ b/components/NavigationMenu/NavigationMenu.js
@@ -6,10 +6,6 @@ export default function NavigationMenu({ menuItems, className, children }) {
     return null;
   }
 
-  if (!menuItems) {
-    return null;
-  }
-
   return (
     <nav
       className={className}


### PR DESCRIPTION
Removed a duplicate `if (!menuItems) { return null; }` check in `components/NavigationMenu/NavigationMenu.js`. This improves code readability and maintainability by eliminating dead code.
Verified by reading the code and running Prettier.
No functional changes were made.
No tests were run as there are no tests in the repository.

---
*PR created automatically by Jules for task [7175176630558874542](https://jules.google.com/task/7175176630558874542) started by @jbphinney*