### PR TITLE
Fix unnecessary effect dependency in useFocusFirstNewResult hook

### DIFF
--- a/hooks/useFocusFirstNewResult.js
+++ b/hooks/useFocusFirstNewResult.js
@@ -27,7 +27,7 @@ export default function useFocusFirstNewResult(posts) {
         return focusIndex;
       });
     }
-  }, [posts, firstNewResultIndex]);
+  }, [posts]);
 
   return { firstNewResultRef, firstNewResultIndex };
 }


### PR DESCRIPTION
Removed `firstNewResultIndex` from the dependency array of the `useEffect` hook in `hooks/useFocusFirstNewResult.js` to prevent unnecessary re-execution of the effect. This improves performance and code clarity by adhering to React hooks best practices.

---
*PR created automatically by Jules for task [13858577969735020081](https://jules.google.com/task/13858577969735020081) started by @jbphinney*