### PR TITLE
Refactor: Remove unnecessary React Fragment in Testimonials component

### DIFF
--- a/components/Testimonials/Testimonials.js
+++ b/components/Testimonials/Testimonials.js
@@ -22,44 +22,42 @@ const cx = className.bind(styles);
  */
 export default function Testimonials({ testimonials }) {
   return (
-    <>
-      <div className={cx('container')}>
-        <FaQuoteRight className={cx('quote-icon')} />
+    <div className={cx('container')}>
+      <FaQuoteRight className={cx('quote-icon')} />
 
-        <Carousel
-          showIndicators={false}
-          showThumbs={false}
-          renderArrowPrev={(clickHandler) => (
-            <FaChevronCircleLeft
-              className={cx('arrow')}
-              onClick={clickHandler}
+      <Carousel
+        showIndicators={false}
+        showThumbs={false}
+        renderArrowPrev={(clickHandler) => (
+          <FaChevronCircleLeft
+            className={cx('arrow')}
+            onClick={clickHandler}
+          />
+        )}
+        renderArrowNext={(clickHandler) => (
+          <FaChevronCircleRight
+            className={cx('arrow')}
+            onClick={clickHandler}
+          />
+        )}
+        infiniteLoop={true}
+        showStatus={false}
+      >
+        {testimonials.map((testimonial, index) => (
+          <TestimonialItem
+            author={testimonial?.testimonialFields?.testimonialAuthor}
+            key={index}
+          >
+            <div
+              className={cx('slide-content')}
+              dangerouslySetInnerHTML={{
+                __html: testimonial?.testimonialFields?.testimonialContent,
+              }}
             />
-          )}
-          renderArrowNext={(clickHandler) => (
-            <FaChevronCircleRight
-              className={cx('arrow')}
-              onClick={clickHandler}
-            />
-          )}
-          infiniteLoop={true}
-          showStatus={false}
-        >
-          {testimonials.map((testimonial, index) => (
-            <TestimonialItem
-              author={testimonial?.testimonialFields?.testimonialAuthor}
-              key={index}
-            >
-              <div
-                className={cx('slide-content')}
-                dangerouslySetInnerHTML={{
-                  __html: testimonial?.testimonialFields?.testimonialContent,
-                }}
-              />
-            </TestimonialItem>
-          ))}
-        </Carousel>
-      </div>
-    </>
+          </TestimonialItem>
+        ))}
+      </Carousel>
+    </div>
   );
 }
 


### PR DESCRIPTION
This PR removes an unnecessary React Fragment from `components/Testimonials/Testimonials.js`. The fragment was wrapping a single child element, which is redundant. This change improves code cleanliness and readability without affecting functionality. I also verified the changes with ESLint.

---
*PR created automatically by Jules for task [15071624823045952045](https://jules.google.com/task/15071624823045952045) started by @jbphinney*