### PR TITLE
🧹 Fix mixed controlled/uncontrolled input in SearchInput

### DIFF
--- a/components/SearchInput/SearchInput.js
+++ b/components/SearchInput/SearchInput.js
@@ -14,9 +14,8 @@ import styles from './SearchInput.module.scss';
 export default function SearchInput({ value, onChange, ...props }) {
   const input = useRef();
 
-  // Clear and focus the input on initial render
+  // Focus the input on initial render
   useEffect(() => {
-    input.current.value = '';
     input.current.focus();
   }, []);
 


### PR DESCRIPTION
🎯 **What:** Removed the imperative `input.current.value = ''` assignment in the `SearchInput` component's `useEffect` hook.
💡 **Why:** This assignment conflicted with the controlled `value` prop, causing mixed controlled/uncontrolled behavior. The component is now correctly controlled by its `value` prop.
✅ **Verification:** Verified that the problematic assignment is removed. Preserved the existing focus-on-mount behavior by retaining the `input.current.focus()` call (and the `autoFocus` prop is also present as a fallback).
✨ **Result:** Improved code health and stability of the SearchInput component.

---
*PR created automatically by Jules for task [4307880693638155690](https://jules.google.com/task/4307880693638155690) started by @jbphinney*