### PR TITLE
Fix potential XSS in Button component by sanitizing href

### DIFF
--- a/components/Button/Button.js
+++ b/components/Button/Button.js
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 
+import { sanitizePath } from '../../utilities';
 import styles from './Button.module.scss';
 
 /**
@@ -37,9 +38,15 @@ export default function Button({
   ].join(' ');
 
   if (href) {
+    const sanitizedHref = sanitizePath(href);
     return (
-      <Link legacyBehavior href={href}>
-        <a role="button" href={href} className={buttonClassName} {...props}>
+      <Link legacyBehavior href={sanitizedHref}>
+        <a
+          role="button"
+          href={sanitizedHref}
+          className={buttonClassName}
+          {...props}
+        >
           {children}
         </a>
       </Link>

--- a/utilities/index.js
+++ b/utilities/index.js
@@ -1,4 +1,5 @@
 import pageTitle from './pageTitle';
 import flatListToHierarchical from './flatListToHierarchical';
+import sanitizePath from './sanitizePath';
 
-export { pageTitle, flatListToHierarchical };
+export { pageTitle, flatListToHierarchical, sanitizePath };

--- a/utilities/sanitizePath.js
+++ b/utilities/sanitizePath.js
@@ -1,0 +1,31 @@
+/**
+ * Sanitizes a path or URL to ensure it is safe for use in a link.
+ *
+ * @param {string} path The path or URL to sanitize.
+ * @returns {string} The sanitized path or URL.
+ */
+export default function sanitizePath(path) {
+  if (!path) {
+    return '/';
+  }
+
+  try {
+    const decodedPath = decodeURIComponent(path);
+    // Remove all whitespace
+    const cleanPath = decodedPath.replace(/\s+/g, '').toLowerCase();
+
+    // Check for potentially unsafe protocols
+    if (
+      cleanPath.startsWith('javascript:') ||
+      cleanPath.startsWith('data:') ||
+      cleanPath.startsWith('vbscript:')
+    ) {
+      return '/';
+    }
+  } catch (e) {
+    // If decodeURIComponent fails, path is likely malformed.
+    return '/';
+  }
+
+  return path;
+}

--- a/utilities/sanitizePath.test.mjs
+++ b/utilities/sanitizePath.test.mjs
@@ -1,0 +1,42 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import sanitizePath from './sanitizePath.js';
+
+test('sanitizePath', async (t) => {
+  await t.test('allows safe relative paths', () => {
+    assert.strictEqual(sanitizePath('/foo'), '/foo');
+    assert.strictEqual(sanitizePath('/foo/bar?baz=qux'), '/foo/bar?baz=qux');
+    assert.strictEqual(sanitizePath('#anchor'), '#anchor');
+  });
+
+  await t.test('allows safe absolute URLs', () => {
+    assert.strictEqual(sanitizePath('http://example.com'), 'http://example.com');
+    assert.strictEqual(sanitizePath('https://example.com/foo'), 'https://example.com/foo');
+    assert.strictEqual(sanitizePath('mailto:user@example.com'), 'mailto:user@example.com');
+    assert.strictEqual(sanitizePath('tel:+1234567890'), 'tel:+1234567890');
+  });
+
+  await t.test('blocks javascript: protocol', () => {
+    assert.strictEqual(sanitizePath('javascript:alert(1)'), '/');
+    assert.strictEqual(sanitizePath('JAVASCRIPT:alert(1)'), '/');
+    assert.strictEqual(sanitizePath('  javascript:alert(1)'), '/');
+    // My implementation removes all whitespace, so 'javascript :alert(1)' becomes 'javascript:alert(1)' and is blocked.
+    assert.strictEqual(sanitizePath('javascript :alert(1)'), '/');
+  });
+
+  await t.test('blocks data: protocol', () => {
+    assert.strictEqual(sanitizePath('data:text/html,Hello'), '/');
+    assert.strictEqual(sanitizePath('DATA:text/html,Hello'), '/');
+  });
+
+  await t.test('blocks vbscript: protocol', () => {
+    assert.strictEqual(sanitizePath('vbscript:msgbox(1)'), '/');
+  });
+
+  await t.test('handles encoded javascript:', () => {
+    // decodeURIComponent('j%61vascript:alert(1)') -> 'javascript:alert(1)'
+    assert.strictEqual(sanitizePath('j%61vascript:alert(1)'), '/');
+    // decodeURIComponent('javascript%3Aalert(1)') -> 'javascript:alert(1)'
+    assert.strictEqual(sanitizePath('javascript%3Aalert(1)'), '/');
+  });
+});


### PR DESCRIPTION
This PR addresses a potential XSS vulnerability in the Button component where the href prop was used directly without validation.

- Added `utilities/sanitizePath.js` to scrub potentially unsafe URLs (javascript:, data:, vbscript:).
- Updated `components/Button/Button.js` to use `sanitizePath` before rendering the link.
- Added tests for `sanitizePath` in `utilities/sanitizePath.test.mjs`.

This prevents malicious javascript execution via the href attribute while preserving legitimate relative and absolute URLs.

---
*PR created automatically by Jules for task [13140193711574247321](https://jules.google.com/task/13140193711574247321) started by @jbphinney*