### PR TITLE
⚡ Prevent content flash on Archive page loading

### DIFF
--- a/wp-templates/archive.js
+++ b/wp-templates/archive.js
@@ -18,13 +18,11 @@ import appConfig from 'app.config';
 
 export default function Archive(props) {
   const { uri, name, __typename } = props.data.nodeByUri;
-  const { data, loading, fetchMore } = useQuery(Archive.query, {
+  const { data: queryData, loading, fetchMore } = useQuery(Archive.query, {
     variables: Archive.variables({ uri }),
   });
 
-  if (loading) {
-    return <></>;
-  }
+  const data = queryData ?? props.data;
 
   const { title: siteTitle, description: siteDescription } =
     data?.generalSettings;


### PR DESCRIPTION
💡 **What:**
Updated `wp-templates/archive.js` to use `props.data` as a fallback when the Apollo `useQuery` hook is in a loading state. Previously, the component returned an empty fragment `<></>` during loading.

🎯 **Why:**
Returning empty content during hydration or refetching causes a "flash of unstyled content" (FOUC) or a flash of invisible content, discarding the HTML already rendered by the server. This negatively impacts Core Web Vitals (LCP, CLS) and user experience.

📊 **Measured Improvement:**
Verified via a reproduction test script (`reproduce_issue.test.mjs` - created and then cleaned up) that the component now renders the title and content from `props` immediately even when `loading` is true, whereas previously it returned `null`. This eliminates the blank screen during hydration.

---
*PR created automatically by Jules for task [5145090778782590483](https://jules.google.com/task/5145090778782590483) started by @jbphinney*