### PR TITLE
⚡ Use stable databaseId as key in TaxonomyTerms

### DIFF
--- a/components/TaxonomyTerms/TaxonomyTerms.js
+++ b/components/TaxonomyTerms/TaxonomyTerms.js
@@ -11,11 +11,11 @@ let cx = classNames.bind(styles);
  * @returns {React.ReactElement} The TaxonomyTerms component
  */
 export default function TaxonomyTerms({ post, taxonomy }) {
-  const termLinks = post?.[taxonomy]?.edges.map((edge, index) => {
-    const { name, uri } = edge.node;
+  const termLinks = post?.[taxonomy]?.edges.map((edge) => {
+    const { name, uri, databaseId } = edge.node;
     return (
       uri && (
-        <Link legacyBehavior key={index} href={uri}>
+        <Link legacyBehavior key={databaseId} href={uri}>
           {name}
         </Link>
       )

--- a/wp-templates/single.js
+++ b/wp-templates/single.js
@@ -86,6 +86,7 @@ Component.query = gql`
       tags {
         edges {
           node {
+            databaseId
             name
             uri
           }
@@ -94,6 +95,7 @@ Component.query = gql`
       categories {
         edges {
           node {
+            databaseId
             name
             uri
           }


### PR DESCRIPTION
This PR addresses a performance and correctness issue in the `TaxonomyTerms` component where array indices were used as keys for a list of links.

Changes:
- Modified `wp-templates/single.js` to include `databaseId` in the `GetPost` query for both `tags` and `categories`.
- Modified `components/TaxonomyTerms/TaxonomyTerms.js` to use `databaseId` as the unique key for each term link.

This ensures stable identity for list items, which is a React best practice for performance and preventing UI bugs during updates.

Verified by running ESLint with `react/no-array-index-key` rule enabled, which now passes.


---
*PR created automatically by Jules for task [3814807746916877065](https://jules.google.com/task/3814807746916877065) started by @jbphinney*