### PR TITLE
Refactor Main component to use classnames/bind

### DIFF
--- a/components/Main/Main.js
+++ b/components/Main/Main.js
@@ -1,6 +1,10 @@
 import * as SELECTORS from 'constants/selectors';
 
+import classNames from 'classnames/bind';
+
 import styles from './Main.module.scss';
+
+const cx = classNames.bind(styles);
 
 /**
  * Render the Main component.
@@ -15,7 +19,7 @@ export default function Main({ children, className, ...props }) {
     <main
       id={SELECTORS.MAIN_CONTENT_ID}
       tabIndex="-1"
-      className={[styles.main, className].join(' ')}
+      className={cx('main', className)}
       {...props}
     >
       {children}


### PR DESCRIPTION
This PR refactors `components/Main/Main.js` to use the `classnames/bind` utility for handling class names. 

🎯 **What:**
- Replaced manual array join `[styles.main, className].join(' ')` with `cx('main', className)` using `classnames/bind`.
- Ordered imports to satisfy linter.

💡 **Why:**
- Improves consistency with other components in the codebase.
- Handles falsy `className` props gracefully (avoids extra spaces or potential errors).
- Improves readability.

✅ **Verification:**
- Verified `classnames` dependency exists in `package.json`.
- Ran `npx eslint components/Main/Main.js` and verified it passes (after auto-fixing import order).
- Verified code logic manually.
- Reverted unrelated changes to `package-lock.json` and other files caused by environment setup/formatting.

---
*PR created automatically by Jules for task [1880243872590843214](https://jules.google.com/task/1880243872590843214) started by @jbphinney*