### PR TITLE
Refactor duplicate CTA in front-page.js

### DIFF
--- a/wp-templates/front-page.js
+++ b/wp-templates/front-page.js
@@ -20,6 +20,24 @@ import { BlogInfoFragment } from 'fragments/GeneralSettings';
 
 const postsPerPage = 3;
 
+const WebVitalsCTA = () => (
+  <section className="cta">
+    <CTA
+      Button={() => (
+        <Button href="/posts">
+          Get Started <FaArrowRight style={{ marginLeft: `1rem` }} />
+        </Button>
+      )}
+    >
+      <span>
+        Learn about Core Web Vitals and how Headless Platform can help
+        you reach your most demanding speed and user experience
+        requirements.
+      </span>
+    </CTA>
+  </section>
+);
+
 export default function Component() {
   const { data, loading } = useQuery(Component.query, {
     variables: Component.variables(),
@@ -68,42 +86,14 @@ export default function Component() {
               </Button>
             </div>
           </section>
-          <section className="cta">
-            <CTA
-              Button={() => (
-                <Button href="/posts">
-                  Get Started <FaArrowRight style={{ marginLeft: `1rem` }} />
-                </Button>
-              )}
-            >
-              <span>
-                Learn about Core Web Vitals and how Headless Platform can help
-                you reach your most demanding speed and user experience
-                requirements.
-              </span>
-            </CTA>
-          </section>
+          <WebVitalsCTA />
           <section className={styles.posts}>
             <Heading className={styles.heading} level="h2">
               Latest Posts
             </Heading>
             <Posts posts={data.posts?.nodes} id="posts-list" />
           </section>
-          <section className="cta">
-            <CTA
-              Button={() => (
-                <Button href="/posts">
-                  Get Started <FaArrowRight style={{ marginLeft: `1rem` }} />
-                </Button>
-              )}
-            >
-              <span>
-                Learn about Core Web Vitals and how Headless Platform can help
-                you reach your most demanding speed and user experience
-                requirements.
-              </span>
-            </CTA>
-          </section>
+          <WebVitalsCTA />
           <section className={styles.testimonials}>
             <Heading className={styles.heading} level="h2">
               Testimonials


### PR DESCRIPTION
Extracted the duplicate CTA section into a reusable `WebVitalsCTA` component within `wp-templates/front-page.js` to improve code maintainability and reduce duplication. Verified with linting.

---
*PR created automatically by Jules for task [1249517127610826133](https://jules.google.com/task/1249517127610826133) started by @jbphinney*