### PR TITLE
🧹 Extract ArchivePostFragment to reduce duplication in archive.js

### DIFF
--- a/fragments/ArchivePage.js
+++ b/fragments/ArchivePage.js
@@ -1,0 +1,25 @@
+import { gql } from '@apollo/client';
+import { FeaturedImage } from '../components';
+
+export const ArchivePostFragment = gql`
+  fragment ArchivePostFragment on ContentNode {
+    id
+    uri
+    date
+    ... on NodeWithTitle {
+      title
+    }
+    ... on NodeWithContentEditor {
+      content
+    }
+    ...FeaturedImageFragment
+    ... on NodeWithAuthor {
+      author {
+        node {
+          name
+        }
+      }
+    }
+  }
+  ${FeaturedImage.fragments.entry}
+`;

--- a/wp-templates/archive.js
+++ b/wp-templates/archive.js
@@ -3,6 +3,7 @@ import { pageTitle } from 'utilities';
 
 import * as MENUS from '../constants/menus';
 import { BlogInfoFragment } from '../fragments/GeneralSettings';
+import { ArchivePostFragment } from '../fragments/ArchivePage';
 import {
   Header,
   Footer,
@@ -11,7 +12,6 @@ import {
   EntryHeader,
   NavigationMenu,
   Posts,
-  FeaturedImage,
   SEO,
 } from '../components';
 import appConfig from 'app.config';
@@ -38,7 +38,7 @@ export default function Archive(props) {
         title={pageTitle(
           props?.data?.generalSettings,
           `${__typename}: ${name}`,
-          siteTitle
+          siteTitle,
         )}
         description={siteDescription}
       />
@@ -70,7 +70,7 @@ export default function Archive(props) {
 Archive.query = gql`
   ${BlogInfoFragment}
   ${NavigationMenu.fragments.entry}
-  ${FeaturedImage.fragments.entry}
+  ${ArchivePostFragment}
   query GetCategoryPage(
     $uri: String!
     $first: Int!
@@ -89,23 +89,7 @@ Archive.query = gql`
         contentNodes(first: $first, after: $after) {
           edges {
             node {
-              id
-              ... on NodeWithTitle {
-                title
-              }
-              ... on NodeWithContentEditor {
-                content
-              }
-              date
-              uri
-              ...FeaturedImageFragment
-              ... on NodeWithAuthor {
-                author {
-                  node {
-                    name
-                  }
-                }
-              }
+              ...ArchivePostFragment
             }
           }
           pageInfo {
@@ -123,23 +107,7 @@ Archive.query = gql`
           contentNodes(first: $first, after: $after) {
             edges {
               node {
-                id
-                ... on NodeWithTitle {
-                  title
-                }
-                ... on NodeWithContentEditor {
-                  content
-                }
-                date
-                uri
-                ...FeaturedImageFragment
-                ... on NodeWithAuthor {
-                  author {
-                    node {
-                      name
-                    }
-                  }
-                }
+                ...ArchivePostFragment
               }
             }
             pageInfo {
@@ -154,23 +122,7 @@ Archive.query = gql`
           contentNodes(first: $first, after: $after) {
             edges {
               node {
-                id
-                ... on NodeWithTitle {
-                  title
-                }
-                ... on NodeWithContentEditor {
-                  content
-                }
-                date
-                uri
-                ...FeaturedImageFragment
-                ... on NodeWithAuthor {
-                  author {
-                    node {
-                      name
-                    }
-                  }
-                }
+                ...ArchivePostFragment
               }
             }
             pageInfo {


### PR DESCRIPTION
🎯 **What:** Extracted duplicated GraphQL fields from `wp-templates/archive.js` into a new `ArchivePostFragment` in `fragments/ArchivePage.js`.
💡 **Why:** This reduces code duplication across `ContentType`, `Category`, and `Tag` nodes in the `GetCategoryPage` query, improving maintainability and ensuring consistent data fetching for content nodes.
✅ **Verification:** Verified the code structure by reading the modified files. Skipped build verification due to missing environment variables, but the refactor is a direct extraction of existing fields. Formatted code with Prettier.
✨ **Result:** The `GetCategoryPage` query is significantly cleaner and less repetitive.

---
*PR created automatically by Jules for task [8920187689253171833](https://jules.google.com/task/8920187689253171833) started by @jbphinney*